### PR TITLE
Updated encore accent background color

### DIFF
--- a/BurntSienna/user.css
+++ b/BurntSienna/user.css
@@ -193,7 +193,9 @@ highlights selected song contains multi-digit song numbers */
 /* Playlist play button color */
 .encore-dark-theme .encore-bright-accent-set,
 .encore-dark-theme .encore-bright-accent-set:hover {
-	background-color: var(--spice-button) !important;
+	--background-base: var(--spice-button-active);
+	--background-highlight: var(--spice-player);
+	--background-press: var(--spice-player);	
 }
 
 /* Volume bar margins */


### PR DESCRIPTION
Fix background color on indicator when Spotify is being played from another device
Before
![image](https://github.com/dannylloyd/spicetify-themes/assets/614532/417ac13a-324b-4890-887d-41aaa734337b)

After
![image](https://github.com/dannylloyd/spicetify-themes/assets/614532/82461d4c-92d5-4589-a8d9-a71fd371fa1a)
